### PR TITLE
Endpoint for Fetching all Users 

### DIFF
--- a/src/helpers/departments.py
+++ b/src/helpers/departments.py
@@ -16,12 +16,14 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 class _Department:
     def __str__(self) -> str:
         raise NotImplementedError
 
     def __int__(self) -> int:
         raise NotImplementedError
+
 
 class _DepartmentElectronics(_Department): 
     def __str__(self) -> str:
@@ -30,12 +32,14 @@ class _DepartmentElectronics(_Department):
     def __int__(self) -> int:
         return 0
 
+
 class _DepartmentAero(_Department): 
     def __str__(self) -> str:
         return 'Aerodynamics'
 
     def __int__(self) -> int:
         return 1
+
 
 class _DepartmentOperations(_Department): 
     def __str__(self) -> str:
@@ -44,12 +48,14 @@ class _DepartmentOperations(_Department):
     def __int__(self) -> int:
         return 2
 
+
 class _DepartmentPowertrain(_Department): 
     def __str__(self) -> str:
         return 'Powertrain'
 
     def __int__(self) -> int:
         return 3
+
 
 class _DepartmentVehiclePerformance(_Department): 
     def __str__(self) -> str:
@@ -58,12 +64,14 @@ class _DepartmentVehiclePerformance(_Department):
     def __int__(self) -> int:
         return 4
 
+
 class _DepartmentRaceEngineering(_Department): 
     def __str__(self) -> str:
         return 'Race Engineering'
 
     def __int__(self) -> int:
         return 5
+
 
 class _DepartmentTier1(_Department): 
     def __str__(self) -> str:
@@ -72,13 +80,15 @@ class _DepartmentTier1(_Department):
     def __int__(self) -> int:
         return 6
 
+
 class _DepartmentNone(_Department): 
     def __str__(self) -> str:
         return 'NON SPECIFIED'
 
     def __int__(self) -> int:
         return 7
-   
+
+
 elec = _DepartmentElectronics()
 aero = _DepartmentAero()
 oper = _DepartmentOperations()
@@ -91,6 +101,7 @@ noDept = _DepartmentNone()
 _number = {int(elec): elec, int(aero): aero, int(oper): oper, int(powertr): powertr, int(vehiclePer): vehiclePer, int(raceEng): raceEng, int(tier1): tier1, int(noDept): noDept}
 
 _strings = {str(elec): elec, str(aero): aero, str(oper): oper, str(powertr): powertr, str(vehiclePer): vehiclePer, str(raceEng): raceEng, str(tier1): tier1, str(noDept): noDept} 
+
 
 def from_number(number: int) -> _Department:
     if number in _number:

--- a/src/plugins/users.py
+++ b/src/plugins/users.py
@@ -169,8 +169,7 @@ class UsersManager:
         return user
 
     def fetch_all_users(self):
-        sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name} WHERE id != 1 AND id != 2 AND id != 3'
-        # sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name}'
+        sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name} WHERE id != 1 AND id != 2'
         result = self._tab.execute(sql)
 
         if len(result) > 0:

--- a/src/plugins/users.py
+++ b/src/plugins/users.py
@@ -169,8 +169,8 @@ class UsersManager:
         return user
 
     def fetch_all_users(self):
-        # sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name} WHERE id != 1 AND id != 2'
-        sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name}'
+        sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name} WHERE id != 1 AND id != 2 AND id != 3'
+        # sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name}'
         result = self._tab.execute(sql)
 
         if len(result) > 0:

--- a/src/plugins/users.py
+++ b/src/plugins/users.py
@@ -168,14 +168,26 @@ class UsersManager:
 
         return user
 
+    def fetch_all_users(self):
+        # sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name} WHERE id != 1 AND id != 2'
+        sql = f'SELECT id, username, creation, privilege, department, meta FROM {self._tab.name}'
+        result = self._tab.execute(sql)
+
+        if len(result) > 0:
+            return result
+        else:
+            return []
+
 
 _manager = UsersManager()
 
 prepare_request = _manager.prepare_webapi_request
+fetch_all_users = _manager.fetch_all_users
 
 
 def create_user(username: str, password: str, privilege: str, department: str, meta: dict) -> None:
     User(username).create(password, privilege, department, meta)
+
 
 # TODO: Remove Dummy Admin User - Here Just for Development
 def load() -> None:

--- a/src/plugins/webapi.py
+++ b/src/plugins/webapi.py
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
+
 import flask
 import flask_jwt_extended
 import flask_cors

--- a/src/webapi/users.py
+++ b/src/webapi/users.py
@@ -123,22 +123,23 @@ def _on_all_users_get() -> str or tuple:
         "users": []
     }
 
-    for user in data:
-        print(user)
+    if data is not None:
+        for user in data:
+            privilege = str(privileges.from_level(user[3]))
+            department = str(departments.from_number(user[4]))
 
-        privilege = str(privileges.from_level(user[3]))
-        department = str(departments.from_number(user[4]))
+            user_object = {
+                "id": user[0],
+                "username": user[1],
+                "creation": user[2],
+                "privilege": privilege,
+                "department": department
+            }
+            response["users"].append(user_object)
 
-        user_object = {
-            "id": user[0],
-            "username": user[1],
-            "creation": user[2],
-            "privilege": privilege,
-            "department": department
-        }
-        response["users"].append(user_object)
-
-    return response, 200
+        return response, 200
+    else:
+        return 'Something went wrong', 501
 
 
 @webapi.endpoint('/users/<user>', methods=['POST', 'GET', 'PATCH'])
@@ -154,7 +155,7 @@ def _users(user: str) -> str or tuple:
 
 
 @webapi.endpoint('/users', methods=['GET'])
-# @privileges.privilege_required(privileges.admin)
+@privileges.privilege_required(privileges.admin)
 def _all_users() -> str or tuple:
     return webapi.route({
         'GET': lambda: _on_all_users_get(),

--- a/src/webapi/users.py
+++ b/src/webapi/users.py
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 from src.plugins import users, webapi
-from src.helpers import privileges
+from src.helpers import privileges, departments
 import json
 
 
@@ -116,6 +116,31 @@ def _on_users_patch() -> str or tuple:
         return repr(err), 400
 
 
+def _on_all_users_get() -> str or tuple:
+    data = users.fetch_all_users()
+
+    response = {
+        "users": []
+    }
+
+    for user in data:
+        print(user)
+
+        privilege = str(privileges.from_level(user[3]))
+        department = str(departments.from_number(user[4]))
+
+        user_object = {
+            "id": user[0],
+            "username": user[1],
+            "creation": user[2],
+            "privilege": privilege,
+            "department": department
+        }
+        response["users"].append(user_object)
+
+    return response, 200
+
+
 @webapi.endpoint('/users/<user>', methods=['POST', 'GET', 'PATCH'])
 @privileges.privilege_required(privileges.admin)
 def _users(user: str) -> str or tuple:
@@ -126,3 +151,12 @@ def _users(user: str) -> str or tuple:
         'GET': lambda: _on_users_get(),
         'PATCH': lambda: _on_users_patch()
     })
+
+
+@webapi.endpoint('/users', methods=['GET'])
+# @privileges.privilege_required(privileges.admin)
+def _all_users() -> str or tuple:
+    return webapi.route({
+        'GET': lambda: _on_all_users_get(),
+    })
+

--- a/tests.py
+++ b/tests.py
@@ -62,8 +62,7 @@ def run() -> None:
             if hasattr(module, 'load'):
                 module.load()
 
-    # run_all_units()
-    run_unit('admin')
+    run_all_units()
 
     pro.kill()
 

--- a/tests.py
+++ b/tests.py
@@ -62,7 +62,8 @@ def run() -> None:
             if hasattr(module, 'load'):
                 module.load()
 
-    run_all_units()
+    # run_all_units()
+    run_unit('admin')
 
     pro.kill()
 

--- a/tests/units/admin.py
+++ b/tests/units/admin.py
@@ -30,8 +30,12 @@ class TestAdminAccount(BaseAccountTests):
         self.username = 'testAdmin'
         self.password = 'testAdmin'
 
+        username2 = 'testAdmin2'
+        password2 = 'testAdmin2'
+
         try:
             users.create_user(self.username, self.password, 'Admin', 'Tier 1', {})
+            users.create_user(username2, password2, 'Admin', 'Electronics', {})
         except KeyError:
             pass
 
@@ -231,6 +235,23 @@ class TestAdminAccount(BaseAccountTests):
         else:
             pass
 
+    def test_get_all_users(self):
+
+        req = webapi.build_request(
+            'users',
+            'GET',
+            token=self.token
+        )
+
+        try:
+            response = request.urlopen(req)
+            data = json.loads(response.read())
+            self.assertTrue(data is [users])
+        except error.HTTPError as err:
+            self.fail(repr(err))
+        else:
+            pass
+
     def test_start_session(self):
         req = webapi.build_request(
             'sessions/admin',
@@ -394,6 +415,8 @@ def suite():
     s.addTest(TestAdminAccount('test_get_changed_department'))
     s.addTest(TestAdminAccount('test_change_wrong_department'))
     s.addTest(TestAdminAccount('test_get_did_not_change_department'))
+
+    s.addTest(TestAdminAccount('test_get_all_users'))
 
     s.addTest(TestAdminAccount('test_start_session'))
     s.addTest(TestAdminAccount('test_stop_session'))

--- a/tests/units/admin.py
+++ b/tests/units/admin.py
@@ -236,7 +236,6 @@ class TestAdminAccount(BaseAccountTests):
             pass
 
     def test_get_all_users(self):
-
         req = webapi.build_request(
             'users',
             'GET',
@@ -246,7 +245,7 @@ class TestAdminAccount(BaseAccountTests):
         try:
             response = request.urlopen(req)
             data = json.loads(response.read())
-            self.assertTrue(data is [users])
+            self.assertTrue('users' in data)
         except error.HTTPError as err:
             self.fail(repr(err))
         else:

--- a/tests/units/anon.py
+++ b/tests/units/anon.py
@@ -141,6 +141,20 @@ class TestAnonAccount(BaseAccountTests):
         else:
             self.fail('Anon User should not access GET')
 
+    def test_get_all_users(self):
+        req = webapi.build_request(
+            'users',
+            'GET',
+            token=self.token,
+        )
+
+        try:
+            request.urlopen(req)
+        except error.HTTPError as err:
+            self.assertTrue(err.code == 401)
+        else:
+            self.fail('Anonymous User Got all Users')
+
     def test_start_session(self):
         req = webapi.build_request(
             'sessions/anon',
@@ -283,6 +297,8 @@ def suite():
 
     s.addTest(TestAnonAccount('test_change_department'))
     s.addTest(TestAnonAccount('test_get_changed_department'))
+
+    s.addTest(TestAnonAccount('test_get_all_users'))
 
     s.addTest(TestAnonAccount('test_start_session'))
     s.addTest(TestAnonAccount('test_stop_session'))

--- a/tests/units/basic.py
+++ b/tests/units/basic.py
@@ -88,6 +88,20 @@ class TestBasicAccount(BaseAccountTests):
         else:
             self.fail('Basic User changed department')
 
+    def test_get_all_users(self):
+        req = webapi.build_request(
+            'users',
+            'GET',
+            token=self.token,
+        )
+
+        try:
+            request.urlopen(req)
+        except error.HTTPError as err:
+            self.assertTrue(err.code == 401)
+        else:
+            self.fail('Basic User Got all Users')
+
     def test_get_changed_department(self):
         req = webapi.build_request(
             'user',
@@ -263,6 +277,8 @@ def suite():
 
     s.addTest(TestBasicAccount('test_change_department'))
     s.addTest(TestBasicAccount('test_get_changed_department'))
+
+    s.addTest(TestBasicAccount('test_get_all_users'))
 
     s.addTest(TestBasicAccount('test_start_session'))
     s.addTest(TestBasicAccount('test_stop_session'))

--- a/tests/units/developer.py
+++ b/tests/units/developer.py
@@ -158,6 +158,22 @@ class TestDeveloperAccount(BaseAccountTests):
         else:
             self.fail('Back-End accepted switching to wrong department ')
 
+    def test_get_all_users(self):
+        req = webapi.build_request(
+            'users',
+            'GET',
+            token=self.token
+        )
+
+        try:
+            response = request.urlopen(req)
+            data = json.loads(response.read())
+            self.assertTrue('users' in data)
+        except error.HTTPError as err:
+            self.fail(repr(err))
+        else:
+            pass
+
     def test_get_didnot_change_department(self):
         req = webapi.build_request(
             'user',
@@ -337,6 +353,8 @@ def suite():
     s.addTest(TestDeveloperAccount('test_get_changed_department'))
     s.addTest(TestDeveloperAccount('test_change_wrong_department'))
     s.addTest(TestDeveloperAccount('test_get_didnot_change_department'))
+
+    s.addTest(TestDeveloperAccount('test_get_all_users'))
 
     s.addTest(TestDeveloperAccount('test_start_session'))
     s.addTest(TestDeveloperAccount('test_stop_session'))

--- a/tests/units/noaccount.py
+++ b/tests/units/noaccount.py
@@ -54,6 +54,19 @@ class TestNoAccount(BaseTest):
         else:
             self.fail()
 
+    def test_get_all_users(self):
+        req = webapi.build_request(
+            'users',
+            'GET',
+        )
+
+        try:
+            request.urlopen(req)
+        except error.HTTPError as err:
+            self.assertTrue(err.code == 401)
+        else:
+            self.fail('No Account User Got all Users')
+
     def test_get_session(self):
         req = webapi.build_request(
             'sessions/test',
@@ -134,6 +147,8 @@ def suite():
 
     s.addTest(TestNoAccount('test_create_user'))
     s.addTest(TestNoAccount('test_get_user'))
+    s.addTest(TestNoAccount('test_get_all_users'))
+
     s.addTest(TestNoAccount('test_start_session'))
     s.addTest(TestNoAccount('test_stop_session'))
     s.addTest(TestNoAccount('test_get_session_json'))


### PR DESCRIPTION
Implemented a `/users` endpoint that lists all registered users from the database - excluding the `anonymous` user and the `intermediate-server` user. Protected and available only to `developer` and `admin` privileges. 

Closes #28 