### PR TITLE
fix: update `gevent` to 21.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,9 @@ Flask-Cors==3.0.10
 Flask-JWT-Extended==4.1.0
 Flask-SocketIO==5.0.1
 future==0.18.2
-gevent==21.1.2
+gevent==21.12.0
 gevent-websocket==0.10.1
-greenlet==1.0.0
+greenlet==1.1.0
 idna==2.10
 importlib-metadata==3.7.3
 itsdangerous==1.1.0


### PR DESCRIPTION
### Changes
- Updates `gevent` to 21.12.0.
- Also updates `greenlet` to 1.1.0 which is required by the updated `gevent`.
- This allows the intermediate server to run on ARM Mac machines, which would be impossible with the previous version of `gevent` as it fails to build.

### Additional Notes
- The backend and intermediate server run and the connection is made.
- I haven't verified the functionality as I don't know enough about what the correct behaviour is, @AndreasDemenagas would be good if you could quickly test that this update doesn't break anything.
- See: https://github.com/gevent/gevent/issues/1721 
